### PR TITLE
Issue #746 Fixed proxy issue with ApacheRequest

### DIFF
--- a/rexsl-test/src/main/java/com/rexsl/test/request/ApacheRequest.java
+++ b/rexsl-test/src/main/java/com/rexsl/test/request/ApacheRequest.java
@@ -87,7 +87,7 @@ public final class ApacheRequest implements Request {
             final Collection<Map.Entry<String, String>> headers,
             final byte[] content) throws IOException {
             final CloseableHttpResponse response =
-                HttpClients.createDefault().execute(
+                HttpClients.createSystem().execute(
                     this.httpRequest(home, method, headers, content)
                 );
             try {


### PR DESCRIPTION
Call to HttpClients#createDefault() was changed to HttpClients#createSystem() so that Apache HttpClient will honor JVM system properties.
